### PR TITLE
Fix focusNode & Validation and error style for TextformField

### DIFF
--- a/lib/colors.dart
+++ b/lib/colors.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 class ColorsTheme {
   static const Color white = Color(0xFFFFFFFF);
   static const Color black = Color(0xFF000000);
+  static const Color red = Color(0xFFFF0000);
   static const Color point = Color(0xFF4B45FF);
   static const Color pointLight1 = Color(0xFFDBDAFF);
   static const Color pointLight2 = Color(0xFFA4A2FF);

--- a/lib/models/signup_model.dart
+++ b/lib/models/signup_model.dart
@@ -3,15 +3,14 @@ import 'package:flutter/material.dart';
 class SignupModel with ChangeNotifier {
   final TextEditingController nameController = TextEditingController();
   final TextEditingController emailController = TextEditingController();
-  final TextEditingController emailValidationController =
-      TextEditingController();
+  final TextEditingController emailValidController = TextEditingController();
   final TextEditingController pwController = TextEditingController();
 
   @override
   void dispose() {
     nameController.dispose();
     emailController.dispose();
-    emailValidationController.dispose();
+    emailValidController.dispose();
     pwController.dispose();
     super.dispose();
   }

--- a/lib/widgets/signup/label_text.dart
+++ b/lib/widgets/signup/label_text.dart
@@ -39,8 +39,6 @@ class LabelText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print(focusNode.hasFocus);
-
     return SizedBox(
       height: 20,
       child: Align(

--- a/lib/widgets/signup/pin_input.dart
+++ b/lib/widgets/signup/pin_input.dart
@@ -37,15 +37,15 @@ class PinInput extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final emailValidationController =
-        Provider.of<SignupModel>(context).emailValidationController;
+    final emailValidController =
+        Provider.of<SignupModel>(context).emailValidController;
 
     return Padding(
       padding: EdgeInsets.symmetric(
         horizontal: 60.h,
       ),
       child: Pinput(
-        controller: emailValidationController,
+        controller: emailValidController,
         length: 6,
         defaultPinTheme: defaultPinTheme,
         focusedPinTheme: focusedPinTheme,

--- a/lib/widgets/signup/signup_button.dart
+++ b/lib/widgets/signup/signup_button.dart
@@ -17,8 +17,8 @@ class SignupButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.symmetric(
-        vertical: focusNode.hasFocus ? 20.h : 70.h,
+      padding: EdgeInsets.only(
+        bottom: focusNode.hasFocus ? 20.h : 70.h,
       ),
       child: ElevatedButton(
         onPressed: () => handlePressed(),

--- a/lib/widgets/signup/signup_textfield.dart
+++ b/lib/widgets/signup/signup_textfield.dart
@@ -4,21 +4,23 @@ import 'package:workout_app/colors.dart';
 
 class SignupTextField extends StatelessWidget {
   final TextEditingController controller;
-  final FocusNode focusNode;
+  final FocusNode myFocusNode;
   final String title;
+  final String? errorText;
 
   const SignupTextField({
     super.key,
     required this.controller,
-    required this.focusNode,
+    required this.myFocusNode,
     required this.title,
+    this.errorText,
   });
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
+    return TextFormField(
       controller: controller,
-      focusNode: focusNode,
+      focusNode: myFocusNode,
       style: TextStyle(
         fontSize: 22.sp,
         fontWeight: FontWeight.w500,
@@ -28,11 +30,16 @@ class SignupTextField extends StatelessWidget {
           bottom: 10,
           top: 5,
         ),
-        hintText: focusNode.hasFocus ? "" : title,
+        hintText: myFocusNode.hasFocus ? "" : title,
         hintStyle: TextStyle(
           fontSize: 22.sp,
           fontWeight: FontWeight.w600,
           color: ColorsTheme.gray600,
+        ),
+        errorText: errorText,
+        errorStyle: TextStyle(
+          fontSize: 14.sp,
+          color: ColorsTheme.red,
         ),
         enabledBorder: const UnderlineInputBorder(
           borderSide: BorderSide(
@@ -44,6 +51,12 @@ class SignupTextField extends StatelessWidget {
           borderSide: BorderSide(
             width: 2,
             color: ColorsTheme.point,
+          ),
+        ),
+        errorBorder: const UnderlineInputBorder(
+          borderSide: BorderSide(
+            width: 2,
+            color: ColorsTheme.red,
           ),
         ),
       ),

--- a/lib/widgets/signup/step1_name.dart
+++ b/lib/widgets/signup/step1_name.dart
@@ -18,7 +18,8 @@ class Step1Name extends StatefulWidget {
 }
 
 class _Step1NameState extends State<Step1Name> {
-  final FocusNode _focusNode = FocusNode();
+  late FocusNode myFocusNode;
+  String? isEmpty;
 
   void _navigateToNext(TextEditingController nameController) {
     if (nameController.text.isNotEmpty) {
@@ -32,18 +33,23 @@ class _Step1NameState extends State<Step1Name> {
         ),
       );
     } else {
-      // alert something
+      setState(() {
+        isEmpty = "이름을 입력해주세요";
+      });
     }
   }
 
   @override
   void initState() {
+    myFocusNode = FocusNode();
+    myFocusNode.addListener(() => setState(() {}));
     super.initState();
   }
 
   @override
   void dispose() {
-    _focusNode.dispose();
+    myFocusNode.dispose();
+    myFocusNode.removeListener(() => setState(() {}));
     super.dispose();
   }
 
@@ -82,18 +88,19 @@ class _Step1NameState extends State<Step1Name> {
                       ),
                       LabelText(
                         title: "이름",
-                        focusNode: _focusNode,
+                        focusNode: myFocusNode,
                         controller: nameController,
                       ),
                       SignupTextField(
                         controller: nameController,
-                        focusNode: _focusNode,
+                        myFocusNode: myFocusNode,
                         title: "이름",
+                        errorText: isEmpty,
                       ),
                     ],
                   ),
                   SignupButton(
-                    focusNode: _focusNode,
+                    focusNode: myFocusNode,
                     handlePressed: () => _navigateToNext(nameController),
                     content: "확인",
                   ),

--- a/lib/widgets/signup/step2_email.dart
+++ b/lib/widgets/signup/step2_email.dart
@@ -18,7 +18,8 @@ class Step2Email extends StatefulWidget {
 }
 
 class _Step2EmailState extends State<Step2Email> {
-  final FocusNode _focusNode = FocusNode();
+  late FocusNode myFocusNode;
+  String? isEmpty;
 
   void _navigateToNext(TextEditingController controller) {
     if (controller.text.isNotEmpty) {
@@ -31,12 +32,24 @@ class _Step2EmailState extends State<Step2Email> {
           ),
         ),
       );
+    } else {
+      setState(() {
+        isEmpty = "올바르지 않은 이메일 형식입니다";
+      });
     }
   }
 
   @override
+  void initState() {
+    myFocusNode = FocusNode();
+    myFocusNode.addListener(() => setState(() {}));
+    super.initState();
+  }
+
+  @override
   void dispose() {
-    _focusNode.dispose();
+    myFocusNode.dispose();
+    myFocusNode.removeListener(() => setState(() {}));
     super.dispose();
   }
 
@@ -75,18 +88,19 @@ class _Step2EmailState extends State<Step2Email> {
                       ),
                       LabelText(
                         title: "이메일",
-                        focusNode: _focusNode,
+                        focusNode: myFocusNode,
                         controller: emailController,
                       ),
                       SignupTextField(
                         controller: emailController,
-                        focusNode: _focusNode,
                         title: "이메일",
+                        myFocusNode: myFocusNode,
+                        errorText: isEmpty,
                       ),
                     ],
                   ),
                   SignupButton(
-                    focusNode: _focusNode,
+                    focusNode: myFocusNode,
                     handlePressed: () => _navigateToNext(emailController),
                     content: "인증번호 받기",
                   ),

--- a/lib/widgets/signup/step3_email_validation.dart
+++ b/lib/widgets/signup/step3_email_validation.dart
@@ -40,8 +40,8 @@ class _Step3EmailValidationState extends State<Step3EmailValidation> {
 
   @override
   Widget build(BuildContext context) {
-    final emailValidationController =
-        Provider.of<SignupModel>(context).emailValidationController;
+    final emailValidController =
+        Provider.of<SignupModel>(context).emailValidController;
 
     return Scaffold(
       body: Container(
@@ -73,35 +73,30 @@ class _Step3EmailValidationState extends State<Step3EmailValidation> {
                     const PinInput(),
                   ],
                 ),
-                Padding(
-                  padding: EdgeInsets.symmetric(
-                    vertical: _focusNode.hasFocus ? 20.h : 70.h,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      TextButton(
-                        onPressed: () => print("clicked"),
-                        style: TextButton.styleFrom(
-                          padding: EdgeInsets.zero,
-                          minimumSize: Size.zero,
-                        ),
-                        child: Text(
-                          "인증번호 재전송",
-                          style: TextStyle(
-                            fontSize: 17.sp,
-                            color: ColorsTheme.point,
-                          ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TextButton(
+                      onPressed: () => print("clicked"),
+                      style: TextButton.styleFrom(
+                        padding: EdgeInsets.zero,
+                        minimumSize: Size.zero,
+                      ),
+                      child: Text(
+                        "인증번호 재전송",
+                        style: TextStyle(
+                          fontSize: 17.sp,
+                          color: ColorsTheme.point,
                         ),
                       ),
-                      SignupButton(
-                        focusNode: _focusNode,
-                        handlePressed: () =>
-                            _navigateToNext(emailValidationController),
-                        content: "확인",
-                      ),
-                    ],
-                  ),
+                    ),
+                    SignupButton(
+                      focusNode: _focusNode,
+                      handlePressed: () =>
+                          _navigateToNext(emailValidController),
+                      content: "확인",
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/widgets/signup/step4_password.dart
+++ b/lib/widgets/signup/step4_password.dart
@@ -5,7 +5,6 @@ import 'package:workout_app/models/signup_model.dart';
 import 'package:workout_app/widgets/signup/aligned_title_text.dart';
 import 'package:workout_app/widgets/signup/label_text.dart';
 import 'package:workout_app/widgets/signup/signup_button.dart';
-import 'package:workout_app/widgets/signup/signup_textfield.dart';
 
 class Step4Password extends StatefulWidget {
   const Step4Password({super.key});
@@ -61,11 +60,10 @@ class _Step4PasswordState extends State<Step4Password> {
                         focusNode: _focusNode,
                         controller: pwController,
                       ),
-                      SignupTextField(
-                        controller: pwController,
-                        focusNode: _focusNode,
-                        title: "비밀번호",
-                      ),
+                      // SignupTextField(
+                      //   controller: pwController,
+                      //   title: "비밀번호",
+                      // ),
                     ],
                   ),
                   SignupButton(


### PR DESCRIPTION
### FocusNode Bug
When the screen is rendered at the first time and click the TextField, `myFocusNode.hasFocus()` doesn't be changed. Even though I click the TextFormField and the cursor appears, `myFocusNode.hasFocus()` is still false. In fact, the state of focusNode doesn't be changed when the screen is rendered.

(If I clicked the screen except for TextFormField and then clicked TextFormField, myFocusNode has been changed properly.)

### FocusNode Solution
Unlike the previous one, I declared the `myFocusNode` typed `FocusNode` with `late`.

And then, in the initState function, I allocated the FocusNode() to myFocusNode and executed the addListener() like    
```
  late FocusNode myFocusNode;

  @override
  void initState() {
    myFocusNode = FocusNode();
    myFocusNode.addListener(() => setState(() {}));
    super.initState();
  }
```
---
### Solution error style for TextFormField
Firstly, I declared the `isEmpty` typed `String?`. And then, in the function named `_navigateToNext`, change the state to the text what I want like 

```
  void _navigateToNext(TextEditingController controller) {
    if (controller.text.isNotEmpty) {
      Navigator.push(
        context,
        MaterialPageRoute(
          builder: (_) => ChangeNotifierProvider(
            create: (_) => SignupModel(),
            child: const Step3EmailValidation(),
          ),
        ),
      );
    } else {
      setState(() {
        isEmpty = "올바르지 않은 이메일 형식입니다";
      });
    }
  }
```

Lastly, I sent this `isEmpty` to the SignupTextField. In the SignupTextField, I add the errorText depending on the isEmpty. Here is the code: 

```
class SignupTextField extends StatelessWidget {
final String? errorText;

const SignupTextField({this.errorText});

Widget build(BuildContext context) {
    return (
        // ...
        errorText: errorText
    );
}
```